### PR TITLE
Make sure that Cecil Looks in the Right Place for MSpec

### DIFF
--- a/Source/Machine.VSTestAdapter/Machine.VSTestAdapter.csproj
+++ b/Source/Machine.VSTestAdapter/Machine.VSTestAdapter.csproj
@@ -76,6 +76,7 @@
     <Compile Include="MSpecTestCase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RunStats.cs" />
+    <Compile Include="ScopedAssemblyResolver.cs" />
     <Compile Include="SpecificationDiscoverer.cs" />
     <Compile Include="SpecificationExecutor.cs" />
     <Compile Include="SpecificationRunListener.cs" />

--- a/Source/Machine.VSTestAdapter/ScopedAssemblyResolver.cs
+++ b/Source/Machine.VSTestAdapter/ScopedAssemblyResolver.cs
@@ -1,0 +1,82 @@
+﻿using Mono.Cecil;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Machine.VSTestAdapter
+{
+    public class ScopedAssemblyResolver : BaseAssemblyResolver
+    {
+        private readonly IAssemblyResolver defaultResolver;
+
+        public ScopedAssemblyResolver(string location)
+        {
+            if (!string.IsNullOrEmpty(location) && Directory.Exists(location))
+                AddSearchDirectory(location);
+
+            // also search the directory that the runner is within
+            AddSearchDirectory(typeof(ScopedAssemblyResolver).Assembly.Location);
+
+            defaultResolver = new DefaultAssemblyResolver();
+        }
+
+        public override AssemblyDefinition Resolve(AssemblyNameReference name)
+        {
+            try
+            {
+                return base.Resolve(name);
+            }
+            catch (AssemblyResolutionException)
+            {
+                return defaultResolver.Resolve(name);
+            }
+        }
+
+        public override AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
+        {
+            if (parameters == null)
+                parameters = new ReaderParameters();
+            // Force the resolver.
+            parameters.AssemblyResolver = this;
+            try
+            {
+                return base.Resolve(name, parameters);
+            }
+            catch (AssemblyResolutionException)
+            {
+                return defaultResolver.Resolve(name, parameters);
+            }
+        }
+
+        public override AssemblyDefinition Resolve(string fullName)
+        {
+            try
+            {
+                return base.Resolve(fullName);
+            }
+            catch (AssemblyResolutionException)
+            {
+                return defaultResolver.Resolve(fullName);
+            }
+        }
+
+        public override AssemblyDefinition Resolve(string fullName, ReaderParameters parameters)
+        {
+            if (parameters == null)
+                parameters = new ReaderParameters();
+            // Force the resolver.
+            parameters.AssemblyResolver = this;
+            try
+            {
+                return base.Resolve(fullName, parameters);
+            }
+            catch (AssemblyResolutionException)
+            {
+                return defaultResolver.Resolve(fullName, parameters);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5.
- Creating ScopedAssemblyResolver that looks in the test assembly location, the vstestadapter location and then the default locations.
- Using the ScopedAssemblyResolver for test discovery.
