### PR TITLE
Fix result reporting for R#

### DIFF
--- a/src/Machine.Specifications.Runner.VisualStudio/Execution/VSProxyAssemblySpecificationRunListener.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio/Execution/VSProxyAssemblySpecificationRunListener.cs
@@ -112,6 +112,7 @@ namespace Machine.VSTestAdapter.Execution
             TestResult testResult = new TestResult(testCase) {
                 ComputerName = Environment.MachineName,
                 Outcome = MapSpecificationResultToTestOutcome(result),
+                DisplayName = testCase.DisplayName
             };
 
             if (result.Exception != null) 


### PR DESCRIPTION
This was preventing R# from marking test results as complete.