### PR TITLE
Add TestCaseFilter support to VSTest Adapter

### DIFF
--- a/src/Machine.Specifications.Runner.VisualStudio.Specs/Configuration/When_adapter_runs_tests.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio.Specs/Configuration/When_adapter_runs_tests.cs
@@ -32,7 +32,7 @@ namespace Machine.VSTestAdapter.Specs.Configuration
                 .WhenToldTo(context => context.RunSettings)
                 .Return(The<IRunSettings>());
 
-            adapter = new MSpecTestAdapter(An<ISpecificationDiscoverer>(), The<ISpecificationExecutor>());
+            adapter = new MSpecTestAdapter(An<ISpecificationDiscoverer>(), The<ISpecificationExecutor>(), An<ISpecificationFilterProvider>());
         };
 
         Because of = () =>

--- a/src/Machine.Specifications.Runner.VisualStudio.Specs/Configuration/When_parsing_configuration_and_mspec_section_is_missing.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio.Specs/Configuration/When_parsing_configuration_and_mspec_section_is_missing.cs
@@ -3,6 +3,7 @@ using Machine.VSTestAdapter.Configuration;
 
 namespace Machine.VSTestAdapter.Specs.Configuration
 {
+    [Tags("Tag1","Tag2")]
     [Subject(typeof(Settings), "Configuration")]
     public class When_parsing_configuration_and_mspec_section_is_missing
     {

--- a/src/Machine.Specifications.Runner.VisualStudio.Specs/Execution/With_AssemblyExecutionSetup.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio.Specs/Execution/With_AssemblyExecutionSetup.cs
@@ -11,21 +11,21 @@ namespace Machine.VSTestAdapter.Specs.Execution
 {
     public abstract class With_AssemblyExecutionSetup : WithFakes
     {
-        static ISpecificationExecutor Executor;
+        static MSpecTestAdapter Executor;
         static CompileContext compiler;
         static Assembly assembly;
 
         Establish context = () =>
         {
             compiler = new CompileContext();
-            Executor = new SpecificationExecutor();
+            Executor = new MSpecTestAdapter();
 
             var assemblyPath = compiler.Compile(SampleFixture.Code);
             assembly = Assembly.LoadFile(assemblyPath);
         };
 
         Because of = () =>
-            Executor.RunAssembly(assembly.Location, An<Settings>(), new Uri("bla://executor"), The<IFrameworkHandle>());
+            Executor.RunTests(new[] { assembly.Location }, An<IRunContext>(), The<IFrameworkHandle>());
 
         Cleanup after = () =>
             compiler.Dispose();

--- a/src/Machine.Specifications.Runner.VisualStudio.Specs/When_there_is_an_unhandled_error_during_test_discovery.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio.Specs/When_there_is_an_unhandled_error_during_test_discovery.cs
@@ -19,7 +19,7 @@ namespace Machine.VSTestAdapter.Specs
                     throw new InvalidOperationException();
                 });
 
-            Adapter = new MSpecTestAdapter(The<ISpecificationDiscoverer>(), An<ISpecificationExecutor>());
+            Adapter = new MSpecTestAdapter(The<ISpecificationDiscoverer>(), An<ISpecificationExecutor>(), An<ISpecificationFilterProvider>());
         };
 
         Because of = () => {

--- a/src/Machine.Specifications.Runner.VisualStudio.Specs/When_there_is_an_unhandled_error_during_test_execution.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio.Specs/When_there_is_an_unhandled_error_during_test_execution.cs
@@ -20,11 +20,11 @@ namespace Machine.VSTestAdapter.Specs
                     Param<Uri>.IsAnything, Param<IFrameworkHandle>.IsAnything))
                 .Throw(new InvalidOperationException());
 
-            Adapter = new MSpecTestAdapter(An<ISpecificationDiscoverer>(), The<ISpecificationExecutor>());
+            Adapter = new MSpecTestAdapter(An<ISpecificationDiscoverer>(), The<ISpecificationExecutor>(), An<ISpecificationFilterProvider>());
         };
 
         Because of = () => { Adapter.RunTests(new[] {"bla"}, An<IRunContext>(), The<IFrameworkHandle>()); };
-        
+
         It should_send_an_error_notification_to_visual_studio = () =>
         {
             The<IFrameworkHandle>()

--- a/src/Machine.Specifications.Runner.VisualStudio.Specs/When_there_is_an_unhandled_error_during_test_execution.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio.Specs/When_there_is_an_unhandled_error_during_test_execution.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using Machine.Fakes;
 using Machine.Specifications;
 using Machine.VSTestAdapter.Configuration;
 using Machine.VSTestAdapter.Discovery;
 using Machine.VSTestAdapter.Execution;
+using Machine.VSTestAdapter.Helpers;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
@@ -11,19 +14,21 @@ namespace Machine.VSTestAdapter.Specs
 {
     public class When_there_is_an_unhandled_error_during_test_execution : WithFakes
     {
-        static MSpecTestAdapter Adapter;
+        static MSpecTestAdapterExecutor Adapter;
 
         Establish context = () =>
         {
             The<ISpecificationExecutor>()
-                .WhenToldTo(d => d.RunAssembly(Param<string>.IsAnything, Param<Settings>.IsNotNull,
+                .WhenToldTo(d => d.RunAssemblySpecifications(Param<string>.IsAnything, Param<VisualStudioTestIdentifier[]>.IsAnything, Param<Settings>.IsNotNull,
                     Param<Uri>.IsAnything, Param<IFrameworkHandle>.IsAnything))
                 .Throw(new InvalidOperationException());
 
-            Adapter = new MSpecTestAdapter(An<ISpecificationDiscoverer>(), The<ISpecificationExecutor>(), An<ISpecificationFilterProvider>());
+            var adapterDiscoverer = new MSpecTestAdapterDiscoverer(An<ISpecificationDiscoverer>());
+            Adapter = new MSpecTestAdapterExecutor(The<ISpecificationExecutor>(), adapterDiscoverer, An<ISpecificationFilterProvider>());
         };
 
-        Because of = () => { Adapter.RunTests(new[] {"bla"}, An<IRunContext>(), The<IFrameworkHandle>()); };
+        Because of = () =>
+            Adapter.RunTests(new[] {new TestCase("a", MSpecTestAdapter.Uri, "dll"), }, An<IRunContext>(), The<IFrameworkHandle>());
 
         It should_send_an_error_notification_to_visual_studio = () =>
         {

--- a/src/Machine.Specifications.Runner.VisualStudio/Configuration/Settings.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio/Configuration/Settings.cs
@@ -18,9 +18,17 @@ namespace Machine.VSTestAdapter.Configuration
             Settings config = new Settings();
 
             XElement mspecConfig = null;
-            try {
-                mspecConfig = XDocument.Parse(xml).XPathSelectElement("RunSettings/MSpec");
-            } catch { }
+            try
+            {
+                if(!string.IsNullOrEmpty(xml))
+                {
+                    mspecConfig = XDocument.Parse(xml).XPathSelectElement("RunSettings/MSpec");
+                }
+            }
+            catch
+            {
+                // ignored
+            }
 
             if (mspecConfig == null)
                 return config;

--- a/src/Machine.Specifications.Runner.VisualStudio/Execution/ISpecificationExecutor.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio/Execution/ISpecificationExecutor.cs
@@ -1,7 +1,5 @@
-﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using System;
-using System.Collections.Generic;
 using Machine.VSTestAdapter.Helpers;
 using Machine.VSTestAdapter.Configuration;
 
@@ -9,8 +7,6 @@ namespace Machine.VSTestAdapter.Execution
 {
     public interface ISpecificationExecutor
     {
-        void RunAssembly(string assemblyPath, Settings settings, Uri adaptorUri, IFrameworkHandle frameworkHandle);
-
-        void RunAssemblySpecifications(string assemblyPath, IEnumerable<VisualStudioTestIdentifier> specifications, Settings settings, Uri adaptorUri, IFrameworkHandle frameworkHandle);
+        void RunAssemblySpecifications(string assemblyPath, VisualStudioTestIdentifier[] specifications, Settings settings, Uri adaptorUri, IFrameworkHandle frameworkHandle);
     }
 }

--- a/src/Machine.Specifications.Runner.VisualStudio/Execution/ISpecificationExecutor.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio/Execution/ISpecificationExecutor.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using System;
+using System.Collections.Generic;
 using Machine.VSTestAdapter.Helpers;
 using Machine.VSTestAdapter.Configuration;
 
@@ -7,6 +8,6 @@ namespace Machine.VSTestAdapter.Execution
 {
     public interface ISpecificationExecutor
     {
-        void RunAssemblySpecifications(string assemblyPath, VisualStudioTestIdentifier[] specifications, Settings settings, Uri adaptorUri, IFrameworkHandle frameworkHandle);
+        void RunAssemblySpecifications(string assemblyPath, IEnumerable<VisualStudioTestIdentifier> specifications, Settings settings, Uri adapterUri, IFrameworkHandle frameworkHandle);
     }
 }

--- a/src/Machine.Specifications.Runner.VisualStudio/Execution/ISpecificationFilterProvider.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio/Execution/ISpecificationFilterProvider.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+namespace Machine.VSTestAdapter.Execution
+{
+    public interface ISpecificationFilterProvider
+    {
+        IEnumerable<TestCase> FilteredTests(IEnumerable<TestCase> testCases, IRunContext runContext, IFrameworkHandle frameworkHandle);
+    }
+}

--- a/src/Machine.Specifications.Runner.VisualStudio/Execution/SpecificationExecutor.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio/Execution/SpecificationExecutor.cs
@@ -12,9 +12,9 @@ namespace Machine.VSTestAdapter.Execution
     public class SpecificationExecutor : ISpecificationExecutor
     {
         public void RunAssemblySpecifications(string assemblyPath,
-                                              VisualStudioTestIdentifier[] specifications,
+                                              IEnumerable<VisualStudioTestIdentifier> specifications,
                                               Settings settings,
-                                              Uri executorUri,
+                                              Uri adapterUri,
                                               IFrameworkHandle frameworkHandle)
         {
             assemblyPath = Path.GetFullPath(assemblyPath);
@@ -25,7 +25,7 @@ namespace Machine.VSTestAdapter.Execution
 #else
                 TestExecutor executor = new TestExecutor();
 #endif
-                VSProxyAssemblySpecificationRunListener listener = new VSProxyAssemblySpecificationRunListener(assemblyPath, frameworkHandle, executorUri, settings);
+                VSProxyAssemblySpecificationRunListener listener = new VSProxyAssemblySpecificationRunListener(assemblyPath, frameworkHandle, adapterUri, settings);
 
                 executor.RunTestsInAssembly(assemblyPath, specifications, listener);
 #if !NETSTANDARD

--- a/src/Machine.Specifications.Runner.VisualStudio/Execution/SpecificationExecutor.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio/Execution/SpecificationExecutor.cs
@@ -11,26 +11,8 @@ namespace Machine.VSTestAdapter.Execution
 {
     public class SpecificationExecutor : ISpecificationExecutor
     {
-        public void RunAssembly(string source, Settings settings, Uri executorUri, IFrameworkHandle frameworkHandle)
-        {
-            source = Path.GetFullPath(source);
-
-#if !NETSTANDARD
-            using (var scope = new IsolatedAppDomainExecutionScope<TestExecutor>(source)) {
-                TestExecutor executor = scope.CreateInstance();
-#else
-                TestExecutor executor = new TestExecutor();
-#endif
-
-                VSProxyAssemblySpecificationRunListener listener = new VSProxyAssemblySpecificationRunListener(source, frameworkHandle, executorUri, settings);
-                executor.RunAllTestsInAssembly(source, listener);
-#if !NETSTANDARD
-           }
-#endif
-        }
-
         public void RunAssemblySpecifications(string assemblyPath,
-                                              IEnumerable<VisualStudioTestIdentifier> specifications,
+                                              VisualStudioTestIdentifier[] specifications,
                                               Settings settings,
                                               Uri executorUri,
                                               IFrameworkHandle frameworkHandle)

--- a/src/Machine.Specifications.Runner.VisualStudio/Execution/SpecificationFilterProvider.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio/Execution/SpecificationFilterProvider.cs
@@ -50,19 +50,24 @@ namespace Machine.VSTestAdapter.Execution
                 return null;
             });
 
+            if (filterExpression == null)
+            {
+                return testCases;
+            }
+
+            handle?.SendMessage(TestMessageLevel.Informational, $"Machine Specifications Visual Studio Test Adapter - Filter property set '{filterExpression.TestCaseFilterValue}'");
+
             var filteredTests = testCases
-                .Where(testCase => filterExpression
-                    .MatchTestCase(testCase, propertyName =>
+                .Where(testCase => filterExpression.MatchTestCase(testCase, propertyName =>
                     {
                         var value = GetPropertyValue(propertyName, testCase);
-                        handle.SendMessage(TestMessageLevel.Informational, $"Machine Specifications Visual Studio Test Adapter -Filter property '{propertyName}' for test '{testCase.Id}' returned '{value}'");
                         return value;
                     }));
 
             return filteredTests;
         }
 
-        object GetPropertyValue(string propertyName, TestCase testCase)
+        object GetPropertyValue(string propertyName, TestObject testCase)
         {
             if (testCaseProperties.TryGetValue(propertyName, out var testProperty))
             {
@@ -92,7 +97,7 @@ namespace Machine.VSTestAdapter.Execution
 
         static string[] TraitContains(TestObject testCase, string traitName)
         {
-            return testCase.Traits
+            return testCase?.Traits?
                 .Where(x => x.Name == traitName)
                 .Select(x => x.Value)
                 .ToArray();

--- a/src/Machine.Specifications.Runner.VisualStudio/Execution/SpecificationFilterProvider.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio/Execution/SpecificationFilterProvider.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Machine.Specifications.Model;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+
+namespace Machine.VSTestAdapter.Execution
+{
+    public class SpecificationFilterProvider : ISpecificationFilterProvider
+    {
+        static readonly TestProperty TagProperty = TestProperty.Register(nameof(Tag), nameof(Tag), typeof(string), typeof(TestCase));
+        static readonly TestProperty SubjectProperty = TestProperty.Register(nameof(Subject), nameof(Subject), typeof(string), typeof(TestCase));
+
+        readonly Dictionary<string, TestProperty> testCaseProperties = new Dictionary<string, TestProperty>(StringComparer.OrdinalIgnoreCase)
+        {
+            [TestCaseProperties.FullyQualifiedName.Id] = TestCaseProperties.FullyQualifiedName,
+            [TestCaseProperties.DisplayName.Id] = TestCaseProperties.DisplayName
+        };
+
+        readonly Dictionary<string, TestProperty> traitProperties = new Dictionary<string, TestProperty>(StringComparer.OrdinalIgnoreCase)
+        {
+            [TagProperty.Id] = TagProperty,
+            [SubjectProperty.Id] = SubjectProperty
+        };
+
+        readonly string[] supportedProperties;
+
+        public SpecificationFilterProvider()
+        {
+            supportedProperties = testCaseProperties.Keys
+                .Concat(traitProperties.Keys)
+                .ToArray();
+        }
+
+
+        public IEnumerable<TestCase> FilteredTests(IEnumerable<TestCase> testCases, IRunContext runContext, IFrameworkHandle handle)
+        {
+            var filterExpression = runContext.GetTestCaseFilter(supportedProperties, propertyName =>
+            {
+                if (testCaseProperties.TryGetValue(propertyName, out var testProperty))
+                {
+                    return testProperty;
+                }
+                if (traitProperties.TryGetValue(propertyName, out var traitProperty))
+                {
+                    return traitProperty;
+                }
+                return null;
+            });
+
+            var filteredTests = testCases
+                .Where(testCase => filterExpression
+                    .MatchTestCase(testCase, propertyName =>
+                    {
+                        var value = GetPropertyValue(propertyName, testCase);
+                        handle.SendMessage(TestMessageLevel.Informational, $"Machine Specifications Visual Studio Test Adapter -Filter property '{propertyName}' for test '{testCase.Id}' returned '{value}'");
+                        return value;
+                    }));
+
+            return filteredTests;
+        }
+
+        object GetPropertyValue(string propertyName, TestCase testCase)
+        {
+            if (testCaseProperties.TryGetValue(propertyName, out var testProperty))
+            {
+                if (testCase.Properties.Contains(testProperty))
+                {
+                    return testCase.GetPropertyValue(testProperty);
+                }
+            }
+
+            if (traitProperties.TryGetValue(propertyName, out var traitProperty))
+            {
+                var val = TraitContains(testCase, traitProperty.Id);
+
+                if (val.Length == 1)
+                {
+                    return val[0];
+                }
+
+                if (val.Length > 1)
+                {
+                    return val;
+                }
+            }
+
+            return null;
+        }
+
+        static string[] TraitContains(TestObject testCase, string traitName)
+        {
+            return testCase.Traits
+                .Where(x => x.Name == traitName)
+                .Select(x => x.Value)
+                .ToArray();
+        }
+    }
+}

--- a/src/Machine.Specifications.Runner.VisualStudio/Execution/TestExecutor.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio/Execution/TestExecutor.cs
@@ -22,18 +22,6 @@ namespace Machine.VSTestAdapter.Execution
         }
 #endif
 
-        public TestExecutor()
-        {
-        }
-
-        public void RunAllTestsInAssembly(string pathToAssembly, ISpecificationRunListener specificationRunListener)
-        {
-            Assembly assemblyToRun = AssemblyHelper.Load(pathToAssembly);
-
-            DefaultRunner mspecRunner = CreateRunner(assemblyToRun, specificationRunListener);
-            mspecRunner.RunAssembly(assemblyToRun);
-        }
-
         private DefaultRunner CreateRunner(Assembly assembly,ISpecificationRunListener specificationRunListener)
         {
             var listener = new AggregateRunListener(new[] {
@@ -48,7 +36,7 @@ namespace Machine.VSTestAdapter.Execution
         {
             DefaultRunner mspecRunner = null;
             Assembly assemblyToRun = null;
-       
+
             try
             {
                 assemblyToRun = AssemblyHelper.Load(pathToAssembly);

--- a/src/Machine.Specifications.Runner.VisualStudio/MSpecTestAdapter.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio/MSpecTestAdapter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Machine.VSTestAdapter.Configuration;
 using Machine.VSTestAdapter.Discovery;
 using Machine.VSTestAdapter.Discovery.BuiltIn;
 using Machine.VSTestAdapter.Execution;
@@ -19,8 +18,8 @@ namespace Machine.VSTestAdapter
         const string ExecutorUri = "executor://machine.vstestadapter";
         public static readonly Uri Uri = new Uri(ExecutorUri);
 
-        readonly MSpecTestAdapterDiscoverer testDiscoverer;
-        readonly MSpecTestAdapterExecutor mSpecTestAdapterExecutor;
+        readonly MSpecTestAdapterDiscoverer testAdapterDiscoverer;
+        readonly MSpecTestAdapterExecutor testAdapterExecutor;
 
         public MSpecTestAdapter()
             : this(new BuiltInSpecificationDiscoverer(), new SpecificationExecutor(), new SpecificationFilterProvider())
@@ -29,24 +28,26 @@ namespace Machine.VSTestAdapter
 
         public MSpecTestAdapter(ISpecificationDiscoverer discoverer, ISpecificationExecutor executor, ISpecificationFilterProvider specificationFilterProvider)
         {
-            testDiscoverer = new MSpecTestAdapterDiscoverer(discoverer);
-            mSpecTestAdapterExecutor = new MSpecTestAdapterExecutor(executor, testDiscoverer, specificationFilterProvider);
+            testAdapterDiscoverer = new MSpecTestAdapterDiscoverer(discoverer);
+            testAdapterExecutor = new MSpecTestAdapterExecutor(executor, testAdapterDiscoverer, specificationFilterProvider);
         }
 
         public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink)
         {
-            Settings settings = Settings.Parse(discoveryContext.RunSettings?.SettingsXml);
-            testDiscoverer.DiscoverTests(sources, settings, logger, discoverySink.SendTestCase);
+            //Debugger.Launch();
+            testAdapterDiscoverer.DiscoverTests(sources, discoveryContext, logger, discoverySink);
         }
 
         public void RunTests(IEnumerable<TestCase> tests, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
-            mSpecTestAdapterExecutor.RunTests(tests, runContext, frameworkHandle);
+            //Debugger.Launch();
+            testAdapterExecutor.RunTests(tests, runContext, frameworkHandle);
         }
 
         public void RunTests(IEnumerable<string> sources, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
-            mSpecTestAdapterExecutor.RunTests(sources, runContext, frameworkHandle);
+            //Debugger.Launch();
+            testAdapterExecutor.RunTests(sources, runContext, frameworkHandle);
         }
 
         public void Cancel()

--- a/src/Machine.Specifications.Runner.VisualStudio/MSpecTestAdapter.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio/MSpecTestAdapter.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using Machine.VSTestAdapter.Configuration;
+using Machine.VSTestAdapter.Discovery;
+using Machine.VSTestAdapter.Discovery.BuiltIn;
+using Machine.VSTestAdapter.Execution;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+
+namespace Machine.VSTestAdapter
+{
+    [FileExtension(".exe")]
+    [FileExtension(".dll")]
+    [ExtensionUri(ExecutorUri)]
+    [DefaultExecutorUri(ExecutorUri)]
+    public class MSpecTestAdapter : ITestDiscoverer, ITestExecutor
+    {
+        const string ExecutorUri = "executor://machine.vstestadapter";
+        public static readonly Uri Uri = new Uri(ExecutorUri);
+
+        readonly MSpecTestAdapterDiscoverer testDiscoverer;
+        readonly MSpecTestAdapterExecutor mSpecTestAdapterExecutor;
+
+        public MSpecTestAdapter()
+            : this(new BuiltInSpecificationDiscoverer(), new SpecificationExecutor(), new SpecificationFilterProvider())
+        {
+        }
+
+        public MSpecTestAdapter(ISpecificationDiscoverer discoverer, ISpecificationExecutor executor, ISpecificationFilterProvider specificationFilterProvider)
+        {
+            testDiscoverer = new MSpecTestAdapterDiscoverer(discoverer);
+            mSpecTestAdapterExecutor = new MSpecTestAdapterExecutor(executor, testDiscoverer, specificationFilterProvider);
+        }
+
+        public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink)
+        {
+            Settings settings = Settings.Parse(discoveryContext.RunSettings?.SettingsXml);
+            testDiscoverer.DiscoverTests(sources, settings, logger, discoverySink.SendTestCase);
+        }
+
+        public void RunTests(IEnumerable<TestCase> tests, IRunContext runContext, IFrameworkHandle frameworkHandle)
+        {
+            mSpecTestAdapterExecutor.RunTests(tests, runContext, frameworkHandle);
+        }
+
+        public void RunTests(IEnumerable<string> sources, IRunContext runContext, IFrameworkHandle frameworkHandle)
+        {
+            mSpecTestAdapterExecutor.RunTests(sources, runContext, frameworkHandle);
+        }
+
+        public void Cancel()
+        {
+        }
+    }
+}

--- a/src/Machine.Specifications.Runner.VisualStudio/MSpecTestAdapterDiscoverer.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio/MSpecTestAdapterDiscoverer.cs
@@ -9,6 +9,7 @@ using Machine.VSTestAdapter.Discovery;
 using Machine.VSTestAdapter.Discovery.BuiltIn;
 using Machine.VSTestAdapter.Helpers;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 namespace Machine.VSTestAdapter
@@ -25,6 +26,12 @@ namespace Machine.VSTestAdapter
         public MSpecTestAdapterDiscoverer(ISpecificationDiscoverer discoverer)
         {
             this.discoverer = discoverer;
+        }
+
+        public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink)
+        {
+            Settings settings = Settings.Parse(discoveryContext.RunSettings?.SettingsXml);
+            DiscoverTests(sources, settings, logger, discoverySink.SendTestCase);
         }
 
         public void DiscoverTests(IEnumerable<string> sources, Settings settings, IMessageLogger logger, Action<TestCase> discoverySinkAction)
@@ -59,7 +66,7 @@ namespace Machine.VSTestAdapter
                 }
                 catch (Exception discoverException)
                 {
-                    logger.SendMessage(TestMessageLevel.Error, $"Machine Specifications Visual Studio Test Adapter - Error while discovering specifications in assembly {assemblyPath} - {discoverException.Message}");
+                    logger.SendMessage(TestMessageLevel.Error, $"Machine Specifications Visual Studio Test Adapter - Error while discovering specifications in assembly {assemblyPath} - {discoverException}");
                 }
             }
 

--- a/src/Machine.Specifications.Runner.VisualStudio/MspecTestAdapterExecutor.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio/MspecTestAdapterExecutor.cs
@@ -4,92 +4,75 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Diagnostics;
-using System.IO;
 using Machine.VSTestAdapter.Execution;
 using Machine.VSTestAdapter.Helpers;
 using Machine.VSTestAdapter.Configuration;
 
 namespace Machine.VSTestAdapter
 {
-    public partial class MSpecTestAdapter : ITestExecutor
+    public class MSpecTestAdapterExecutor
     {
-        public void Cancel()
+        readonly ISpecificationExecutor executor;
+        readonly MSpecTestAdapterDiscoverer discover;
+        readonly ISpecificationFilterProvider specificationFilterProvider;
+
+        public MSpecTestAdapterExecutor(ISpecificationExecutor executor, MSpecTestAdapterDiscoverer discover, ISpecificationFilterProvider specificationFilterProvider)
         {
-            // Not supported
+            this.executor = executor;
+            this.discover = discover;
+            this.specificationFilterProvider = specificationFilterProvider;
         }
 
         public void RunTests(IEnumerable<string> sources, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
             //Debugger.Launch();
 
-            frameworkHandle.SendMessage(TestMessageLevel.Informational, "Machine Specifications Visual Studio Test Adapter - Executing Specifications.");
-
-            Settings settings = GetSettings(runContext);
-
-            foreach (string currentAsssembly in sources.Distinct())
-            {
-                try
-                {
-#if !NETSTANDARD
-                    if (!File.Exists(Path.Combine(Path.GetDirectoryName(Path.GetFullPath(currentAsssembly)), "Machine.Specifications.dll")))
-                    {
-                        frameworkHandle.SendMessage(TestMessageLevel.Informational, String.Format("Machine.Specifications.dll not found for {0}", currentAsssembly));
-                        continue;
-                    }
-#endif
-
-                    frameworkHandle.SendMessage(TestMessageLevel.Informational, String.Format("Machine Specifications Visual Studio Test Adapter - Executing tests in {0}", currentAsssembly));
-
-                    this.executor.RunAssembly(currentAsssembly, settings, uri, frameworkHandle);
-                }
-                catch (Exception ex)
-                {
-                    frameworkHandle.SendMessage(TestMessageLevel.Error, String.Format("Machine Specifications Visual Studio Test Adapter - Error while executing specifications in assembly {0} - {1}", currentAsssembly, ex.Message));
-                }
-            }
-
-            frameworkHandle.SendMessage(TestMessageLevel.Informational, String.Format("Complete on {0} assemblies ", sources.Count()));
-            
+            frameworkHandle.SendMessage(TestMessageLevel.Informational, "Machine Specifications Visual Studio Test Adapter - Executing Source Specifications.");
+            var testsToRun = new List<TestCase>();
+            DiscoverTests(sources, runContext, frameworkHandle, testsToRun);
+            RunTests(testsToRun, runContext, frameworkHandle);
+            frameworkHandle.SendMessage(TestMessageLevel.Informational, "Machine Specifications Visual Studio Test Adapter - Executing Source Specifications Complete.");
         }
 
         public void RunTests(IEnumerable<TestCase> tests, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
             //Debugger.Launch();
 
-            frameworkHandle.SendMessage(TestMessageLevel.Informational, "Machine Specifications Visual Studio Test Adapter - Executing Specifications.");
+            frameworkHandle.SendMessage(TestMessageLevel.Informational, "Machine Specifications Visual Studio Test Adapter - Executing Test Specifications.");
+            var executedSpecCount = 0;
+            var settings = Settings.Parse(runContext.RunSettings?.SettingsXml);
+            var currentAssembly = string.Empty;
 
-            int executedSpecCount = 0;
-
-            Settings settings = GetSettings(runContext);
-
-            string currentAsssembly = string.Empty;
             try
             {
+                var testCases = tests.ToArray();
+                foreach (var grouping in testCases.GroupBy(x => x.Source))
+                {
+                    currentAssembly = grouping.Key;
+                    frameworkHandle.SendMessage(TestMessageLevel.Informational, $"Machine Specifications Visual Studio Test Adapter - Executing test cases in {currentAssembly}");
 
-                foreach (IGrouping<string, TestCase> grouping in tests.GroupBy(x => x.Source)) {
-                    currentAsssembly = grouping.Key;
-                    frameworkHandle.SendMessage(TestMessageLevel.Informational, string.Format("Machine Specifications Visual Studio Test Adapter - Executing tests in {0}", currentAsssembly));
+                    var filteredTests = specificationFilterProvider.FilteredTests(grouping.AsEnumerable(), runContext, frameworkHandle);
 
-                    List<VisualStudioTestIdentifier> testsToRun = grouping.Select(test => test.ToVisualStudioTestIdentifier()).ToList();
+                    var testsToRun = filteredTests
+                        .Select(test => test.ToVisualStudioTestIdentifier())
+                        .ToList();
 
-                    this.executor.RunAssemblySpecifications(currentAsssembly, testsToRun, settings, uri, frameworkHandle);
+                    executor.RunAssemblySpecifications(currentAssembly, testsToRun, settings, MSpecTestAdapter.Uri, frameworkHandle);
                     executedSpecCount += grouping.Count();
                 }
 
-                frameworkHandle.SendMessage(TestMessageLevel.Informational, String.Format("Machine Specifications Visual Studio Test Adapter - Execution Complete - {0} specifications in {1} assemblies.", executedSpecCount, tests.GroupBy(x => x.Source).Count()));
-            } catch (Exception ex)
-            {
-                frameworkHandle.SendMessage(TestMessageLevel.Error, string.Format("Machine Specifications Visual Studio Test Adapter - Error while executing specifications in assembly {0} - {1}", currentAsssembly, ex.Message));
+                frameworkHandle.SendMessage(TestMessageLevel.Informational, $"Machine Specifications Visual Studio Test Adapter - Execution Complete - {executedSpecCount} specifications in {testCases.GroupBy(x => x.Source).Count()} assemblies.");
             }
-            finally
+            catch (Exception ex)
             {
+                frameworkHandle.SendMessage(TestMessageLevel.Error, $"Machine Specifications Visual Studio Test Adapter - Error while executing specifications in assembly {currentAssembly} - {ex.Message}");
             }
         }
 
-        private static Settings GetSettings(IDiscoveryContext runContext)
+        void DiscoverTests(IEnumerable<string> sources, IRunContext discoveryContext, IMessageLogger logger, List<TestCase> testsToRun)
         {
-            return Settings.Parse(runContext?.RunSettings?.SettingsXml);
+            Settings settings = Settings.Parse(discoveryContext.RunSettings?.SettingsXml);
+            discover.DiscoverTests(sources, settings, logger, testsToRun.Add);
         }
     }
 }


### PR DESCRIPTION
- [x] Remove partial classes (they should only be used for code generation)
- [x] Allow the execurtor to discover tests
- [x] Filter tests using properties and traits
- [x] Test in Visual Studio and `dotnet test`

https://github.com/machine/machine.specifications/issues/327