### PR TITLE
Upgrade NuGet packages for VSTest / DevOps

### DIFF
--- a/src/Machine.Specifications.Runner.VisualStudio.Specs/Machine.Specifications.Runner.VisualStudio.Specs.csproj
+++ b/src/Machine.Specifications.Runner.VisualStudio.Specs/Machine.Specifications.Runner.VisualStudio.Specs.csproj
@@ -6,13 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Machine.Fakes.Moq" Version="2.10.0" />
+    <PackageReference Include="Machine.Fakes.Moq" Version="2.11.0" />
     <PackageReference Include="Machine.Specifications" Version="1.0.0" />
     <PackageReference Include="Machine.Specifications.Should" Version="1.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.2.1" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.9.0" Condition="'$(TargetFramework)'=='netcoreapp2.1'" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="11.0.0" Condition="'$(TargetFramework)'=='net472'" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.5.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.5.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Machine.Specifications.Runner.VisualStudio/Machine.Specifications.Runner.VisualStudio.csproj
+++ b/src/Machine.Specifications.Runner.VisualStudio/Machine.Specifications.Runner.VisualStudio.csproj
@@ -21,15 +21,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="[0.10-*, 0.11)" />
-    <PackageReference Include="Machine.Specifications" Version="[0.11.0,2.0.0)" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="[15.0.0,17.0.0)" PrivateAssets="All" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net452'">
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="11.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.5.0" PrivateAssets="All" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.2" />
+    <PackageReference Include="Machine.Specifications" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Hitting an issue with DevOps VSTest. Could be due to an old version.
(v15 doesn't support net451 but v16 does.)

Machine Specifications Visual Studio Test Adapter - Error while executing specifications in assembly  - System.Runtime.Remoting.RemotingException: Object '/bc15fff7_47ac_4f9d_9061_df93953c370c/_kv9z__fqrqfm9yrzy1+38hl_6.rem' has been disconnected or does not exist at the server.
```
Server stack trace: 
   at System.Runtime.Remoting.Channels.ChannelServices.CheckDisconnectedOrCreateWellKnownObject(IMessage msg)
   at System.Runtime.Remoting.Channels.ChannelServices.SyncDispatchMessage(IMessage msg)

Exception rethrown at [0]: 
   at System.Runtime.Remoting.Proxies.RealProxy.HandleReturnMessage(IMessage reqMsg, IMessage retMsg)
   at System.Runtime.Remoting.Proxies.RealProxy.PrivateInvoke(MessageData& msgData, Int32 type)
   at Machine.Specifications.Runner.ISpecificationRunListener.OnFatalError(ExceptionResult exception)
```