### PR TITLE
Changed testcase properties to use Label to match mstest filter format

### DIFF
--- a/src/Machine.Specifications.Runner.VisualStudio/Execution/SpecificationFilterProvider.cs
+++ b/src/Machine.Specifications.Runner.VisualStudio/Execution/SpecificationFilterProvider.cs
@@ -18,8 +18,8 @@ namespace Machine.Specifications.Runner.VisualStudio.Execution
 
         private readonly Dictionary<string, TestProperty> testCaseProperties = new Dictionary<string, TestProperty>(StringComparer.OrdinalIgnoreCase)
         {
-            [TestCaseProperties.FullyQualifiedName.Id] = TestCaseProperties.FullyQualifiedName,
-            [TestCaseProperties.DisplayName.Id] = TestCaseProperties.DisplayName
+            [TestCaseProperties.FullyQualifiedName.Label] = TestCaseProperties.FullyQualifiedName,
+            [TestCaseProperties.DisplayName.Label] = TestCaseProperties.DisplayName
         };
 
         private readonly Dictionary<string, TestProperty> traitProperties = new Dictionary<string, TestProperty>(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
Previously needed `dotnet test --filter "TestCase.FullyQualifiedName=FailingTest.When_adding_two_numbers::should_be_greater_than_ten"`

Now matches MSTest filter format `dotnet test --filter "FullyQualifiedName=FailingTest.When_adding_two_numbers::should_be_greater_than_ten"`

This is to solve failed mspec test re-runs not actually re-running via VSTest@2 in Azure DevOps. The re-run process automatically adds tests into the filter param using the latter format.